### PR TITLE
[V3 Deleted] Add guild only check to deleter group 

### DIFF
--- a/deleter/deleter.py
+++ b/deleter/deleter.py
@@ -55,6 +55,7 @@ class Deleter(commands.Cog):
             await self.conf.channel(message.channel).messages.set(c["messages"])
 
     @commands.group()
+    @commands.guild_only()
     @checks.mod_or_permissions(manage_messages=True)
     async def deleter(self, ctx):
         """Group command for commands dealing with auto-timed deletion"""


### PR DESCRIPTION
As noticed in your support server, if someone tries to use the deleter commands in a dm, it just errors at them because the bot can't check the guild settings for permissions and other things, this just makes the command not run in dms so they can only use in a server