### PR TITLE
[targeter] api

### DIFF
--- a/targeter/targeter.py
+++ b/targeter/targeter.py
@@ -691,6 +691,17 @@ class Targeter(commands.Cog):
             return []
         return all_passed.intersection(*passed)
 
+    # API for other cogs
+    async def args_to_list(self, ctx: commands.Context, args: str):
+        """
+        Returns a list of members from the given args, which are
+        expected to follow the style in the Args converter above.
+        """
+        args = await Args().convert(ctx, args)
+        compact = functools.partial(self.lookup, ctx, args)
+        matched = await self.bot.loop.run_in_executor(None, compact)
+        return matched
+
     @checks.bot_has_permissions(embed_links=True)
     @commands.guild_only()
     @commands.group(invoke_without_command=True)


### PR DESCRIPTION
Adds a function `args_to_list` that converts a string to a member list without ignoring exceptions, so that BadArgument exceptions will raise if this is used in another cog's converter. [example usage](https://github.com/phenom4n4n/phen-cogs/blob/role-targeter/roleutils/converters.py#L91)