### PR TITLE
[Maintenance] Add `--end-after-restart` option

### DIFF
--- a/maintenance/__init__.py
+++ b/maintenance/__init__.py
@@ -10,3 +10,4 @@ __red_end_user_data_statement__ = (
 async def setup(bot):
     cog = Maintenance(bot)
     await bot.add_cog(cog)
+    await cog.initialize()

--- a/maintenance/classes.py
+++ b/maintenance/classes.py
@@ -6,7 +6,9 @@ class ScheduledMaintenance:
         if not whitelist:
             whitelist = []
         self.start = start + time.time()
-        if end:
+        if end is True:
+            self.end = True
+        elif end:
             if after:
                 self.end = end + self.start
             else:

--- a/maintenance/converters.py
+++ b/maintenance/converters.py
@@ -23,6 +23,7 @@ class Margs(Converter):
         _end = parser.add_mutually_exclusive_group()
         _end.add_argument("--end-after", nargs="*", dest="end", default=[])
         _end.add_argument("--end-in", nargs="*", dest="endin", default=[])
+        _end.add_argument("--end-after-restart", dest="end_after_restart", action="store_true")
         try:
             vals = vars(parser.parse_args(argument.split(" ")))
         except Exception as exc:
@@ -35,6 +36,8 @@ class Margs(Converter):
         if end_seconds == None:
             end_seconds = convert_time(vals.get("endin", None))
             after = False
+        if vals.get("end_after_restart", False):
+            end_seconds = True
         if start_seconds:
             if end_seconds:
                 scheduled = ScheduledMaintenance(


### PR DESCRIPTION
I always forget to disable maintenance after bot restart and usually, that's when I want it to end so here's a PR adding this functionality...

Is it tested? Actually yes.