### PR TITLE
3.5 breaking changes

### DIFF
--- a/authgg/__init__.py
+++ b/authgg/__init__.py
@@ -1,5 +1,5 @@
 from .authgg import AuthGG
 
 
-def setup(bot):
-    bot.add_cog(AuthGG(bot))
+async def setup(bot):
+    await bot.add_cog(AuthGG(bot))

--- a/authgg/authgg.py
+++ b/authgg/authgg.py
@@ -24,7 +24,7 @@ SOFTWARE.
 
 from redbot.core.utils.predicates import MessagePredicate
 from redbot.core.utils.chat_formatting import humanize_list, inline
-from redbot.core import commands, Config, checks
+from redbot.core import commands, Config
 from typing import Optional
 import discord
 import asyncio
@@ -135,7 +135,7 @@ class AuthGG(commands.Cog):
                     "I was unable to delete your command message due to lack of perms.  It is recommended to due so to prevent your user's password from getting leaked."
                 )
 
-    @checks.is_owner()
+    @commands.is_owner()
     @authgg.group()
     async def keys(self, ctx):
         """Manage API keys for auth.gg"""
@@ -183,7 +183,7 @@ class AuthGG(commands.Cog):
         message = f"The following keys are currently registered: {humanize_list(list(map(inline, keys.keys())))}"
         await ctx.send(message)
 
-    @checks.is_owner()
+    @commands.is_owner()
     @authgg.group()
     async def roles(self, ctx):
         """Control what roles have access to reseting a user's HWID"""

--- a/color/__init__.py
+++ b/color/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(Color(bot))
+async def setup(bot):
+    await bot.add_cog(Color(bot))

--- a/color/color.py
+++ b/color/color.py
@@ -26,7 +26,7 @@ import io
 import re
 
 import discord
-from redbot.core import Config, checks, commands
+from redbot.core import Config, commands
 
 from colour import Color as col
 from colour import rgb2hex
@@ -147,7 +147,7 @@ class Color(commands.Cog):
         """Group command for color commands"""
         pass
 
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     @color.command()
     async def name(self, ctx, name):
         """Provides the hexadecimal value, RGB value and HSL value of a passed color.  For example, pass `red` or `blue` as the name argument."""
@@ -159,7 +159,7 @@ class Color(commands.Cog):
         except (ValueError, AttributeError):
             await ctx.send("That color is not recognized.")
 
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     @color.command()
     async def hex(self, ctx, hexa: str):
         """Provides the RGB value and HSL value of a passed hexadecimal value.  Hexadecimal value must in the format of something like `#ffffff` or `0xffffff` to be used."""
@@ -175,7 +175,7 @@ class Color(commands.Cog):
                 "Invalid formatting for the hexadecimal.  Must be the hexadecimal value, with an optional `0x` or `#` in the beginning."
             )
 
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     @color.command()
     async def rgb(self, ctx, highest: int, r: float, g: float, b: float):
         """Provides the hexadecimal value and HSL value of the rgb value given.  Each value must have a space between them.  Highest argument must be 1 or 255, indicating the highest value of a single value (r, g, or b)."""
@@ -192,7 +192,7 @@ class Color(commands.Cog):
         except (ValueError, AttributeError):
             await ctx.send("That rgb number is not recognized.")
 
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     @color.command()
     async def hsl(self, ctx, h: float, s: float, l: float):
         """Provides the hexadecimal value and the RGB value of the hsl value given.  Each value must have a space between them."""
@@ -203,7 +203,7 @@ class Color(commands.Cog):
         except (ValueError, AttributeError):
             await ctx.send("That hsl number is not recognized.")
 
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     @color.command()
     async def decimal(self, ctx, decimal: int):
         """Provides the RGB value of the decimal value given."""
@@ -213,7 +213,7 @@ class Color(commands.Cog):
         except (ValueError, AttributeError):
             await ctx.send("That decimal value is not recognized.")
 
-    @checks.admin()
+    @commands.admin()
     @color.command()
     async def msgshort(self, ctx, enable: bool):
         """Enable or disable the in-message shortcut.

--- a/commandchart/__init__.py
+++ b/commandchart/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(CommandChart(bot))
+async def setup(bot):
+    await bot.add_cog(CommandChart(bot))

--- a/commandchart/commandchart.py
+++ b/commandchart/commandchart.py
@@ -34,7 +34,7 @@ import typing
 from io import BytesIO
 
 import discord
-from redbot.core import checks, commands
+from redbot.core import commands
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -127,7 +127,7 @@ class CommandChart(commands.Cog):
         image_object.seek(0)
         return image_object
 
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     @commands.guild_only()
     @commands.command()
     async def commandchart(

--- a/cooldown/__init__.py
+++ b/cooldown/__init__.py
@@ -1,5 +1,5 @@
 from .cooldown import Cooldown
 
 
-def setup(bot):
-    bot.add_cog(Cooldown(bot))
+async def setup(bot):
+    await bot.add_cog(Cooldown(bot))

--- a/cooldown/cooldown.py
+++ b/cooldown/cooldown.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from redbot.core import commands, checks, Config
+from redbot.core import commands, Config
 from discord.ext import commands as dc
 import asyncio
 import time
@@ -63,7 +63,7 @@ class Cooldown(commands.Cog):
                 }
                 commands.cooldown(entry[1], entry[2], switch[entry[3]])(cmd)
 
-    @checks.is_owner()
+    @commands.is_owner()
     @commands.group()
     async def cooldown(self, ctx):
         """Group command for working with cooldowns for commands."""

--- a/deleter/__init__.py
+++ b/deleter/__init__.py
@@ -5,6 +5,6 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
+async def setup(bot):
     cog = Deleter(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/deleter/deleter.py
+++ b/deleter/deleter.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from copy import deepcopy as dc
 
 import discord
-from redbot.core import Config, checks, commands
+from redbot.core import Config, commands
 from redbot.core.utils import AsyncIter
 from redbot.core.utils.chat_formatting import humanize_list
 
@@ -92,29 +92,28 @@ class Deleter(commands.Cog):
             c["messages"][str(message.id)] = time.time() + int(c["wait"])
             await self.conf.channel(message.channel).messages.set(c["messages"])
 
-    @commands.group()
+    @commands.group(invoke_without_command=True)
     @commands.guild_only()
-    @checks.mod_or_permissions(manage_messages=True)
+    @commands.mod_or_permissions(manage_messages=True)
     async def deleter(self, ctx):
         """Group command for commands dealing with auto-timed deletion.
 
         To see what channels are currently being tracked, use this command with no subcommands passed."""
-        if ctx.invoked_subcommand is None:
-            async with self.lock:
-                channels = await self.conf.all_channels()
-            sending = ""
-            for c, data in channels.items():
-                c = self.bot.get_channel(int(c))
-                if c is None:
-                    continue
-                if c.guild.id == ctx.guild.id and int(data["wait"]) != 0:
-                    sending += f"{c.mention}: {data['wait']} seconds\n"
-            if sending:
-                await ctx.send(sending)
-            else:
-                await ctx.send(
-                    f"No channels are currently being tracked.  Add one by using `{ctx.prefix}deleter channel`."
-                )
+        async with self.lock:
+            channels = await self.conf.all_channels()
+        sending = ""
+        for c, data in channels.items():
+            c = self.bot.get_channel(int(c))
+            if c is None:
+                continue
+            if c.guild.id == ctx.guild.id and int(data["wait"]) != 0:
+                sending += f"{c.mention}: {data['wait']} seconds\n"
+        if sending:
+            await ctx.send(sending)
+        else:
+            await ctx.send(
+                f"No channels are currently being tracked.  Add one by using `{ctx.prefix}deleter channel`."
+            )
 
     @deleter.command()
     async def channel(self, ctx, channel: discord.TextChannel, wait):

--- a/editor/__init__.py
+++ b/editor/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(Editor(bot))
+async def setup(bot):
+    await bot.add_cog(Editor(bot))

--- a/editor/editor.py
+++ b/editor/editor.py
@@ -25,7 +25,7 @@ SOFTWARE.
 from typing import Union
 
 import discord
-from redbot.core import checks, commands
+from redbot.core import commands
 
 
 class Editor(commands.Cog):
@@ -39,7 +39,7 @@ class Editor(commands.Cog):
         return
 
     @commands.command()
-    @checks.admin()
+    @commands.admin()
     async def editmessage(
         self, ctx, ecid: int, editid: int, ccid: int, *, content: Union[int, str]
     ):

--- a/evolution/__init__.py
+++ b/evolution/__init__.py
@@ -17,5 +17,5 @@ async def setup(bot):
     if not is_global:
         raise RuntimeError("Bank must be global for this cog to work.")
     cog = Evolution(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)
     await cog.utils.initialize()

--- a/evolution/evolution.py
+++ b/evolution/evolution.py
@@ -32,7 +32,7 @@ from datetime import timedelta
 from typing import Literal, Optional
 
 import discord
-from redbot.core import Config, checks, commands, errors
+from redbot.core import Config, commands, errors
 from redbot.core.bot import Red
 from redbot.core.utils import AsyncIter
 from redbot.core.utils.chat_formatting import box, humanize_number, humanize_timedelta, inline
@@ -124,7 +124,7 @@ class Evolution(commands.Cog):
         await self.red_delete_data_for_user(requester="user", user_id=ctx.author.id)
         await ctx.send("Data deleted.  Your game data has been reset.")
 
-    @checks.is_owner()
+    @commands.is_owner()
     @evolution.group()
     async def tasks(self, ctx):
         """View the status of the cog tasks.
@@ -141,7 +141,7 @@ class Evolution(commands.Cog):
         message = self.utils.format_task(statuses["income"])
         await ctx.send(message)
 
-    @checks.is_owner()
+    @commands.is_owner()
     @evolution.command(hidden=True)
     async def removeuser(self, ctx, user: discord.User):
         """Removes a user from the market place if they are stuck for some reason.
@@ -349,7 +349,7 @@ class Evolution(commands.Cog):
         if highest_level < 0:
             highest_level = 0
 
-        controls = copy.deepcopy(DEFAULT_CONTROLS)
+        controls = dict(DEFAULT_CONTROLS)
         controls["\N{MONEY BAG}"] = self.utils.shop_control_callback
         await menu(ctx, embed_list, controls, page=highest_level)
 
@@ -591,7 +591,7 @@ class Evolution(commands.Cog):
         """Claim a perk from your stash"""
         return await ctx.send("This command is not available.  Check back soon!")
 
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     @evolution.command(aliases=["by"])
     async def backyard(self, ctx, use_menu: bool = False):
         """Where ya animals live!  Pass 1 or true to put it in a menu."""

--- a/evolution/info.json
+++ b/evolution/info.json
@@ -5,6 +5,6 @@
     "short" : "Buy and get animals to get more economy credits!",
     "description" : "Buy animals using economy credits or get them every 10 minutes, and gain a certain amount of credits every minute!",
     "tags" : ["fun"],
-    "requirements" : [],
+    "requirements" : ["tabulate"],
     "hidden" : false
 }

--- a/grammar/__init__.py
+++ b/grammar/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(Grammar(bot))
+async def setup(bot):
+    await bot.add_cog(Grammar(bot))

--- a/grammar/info.json
+++ b/grammar/info.json
@@ -1,0 +1,10 @@
+{
+    "author" : ["Neuro Assassin"],
+    "install_msg" : "Thank you for downloading this cog.",
+    "name" : "grammer",
+    "short" : "Get words related to the specified arguments",
+    "description" : "Get words related to the specified arguments",
+    "tags" : [],
+    "requirements" : [],
+    "hidden" : false
+}

--- a/listpermissions/__init__.py
+++ b/listpermissions/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(ListPermissions(bot))
+async def setup(bot):
+    await bot.add_cog(ListPermissions(bot))

--- a/maintenance/__init__.py
+++ b/maintenance/__init__.py
@@ -9,4 +9,4 @@ __red_end_user_data_statement__ = (
 
 async def setup(bot):
     cog = Maintenance(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/maintenance/maintenance.py
+++ b/maintenance/maintenance.py
@@ -28,7 +28,7 @@ from datetime import datetime
 from typing import Literal
 
 import discord
-from redbot.core import Config, checks, commands
+from redbot.core import Config, commands
 
 from .converters import Margs
 
@@ -131,7 +131,7 @@ class Maintenance(commands.Cog):
         raise LIStsSTaRtaTiNDeX1(message)
         return False
 
-    @checks.is_owner()
+    @commands.is_owner()
     @commands.group()
     async def maintenance(self, ctx):
         """Control the bot's maintenance."""

--- a/minesweeper/__init__.py
+++ b/minesweeper/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(Minesweeper(bot))
+async def setup(bot):
+    await bot.add_cog(Minesweeper(bot))

--- a/opensea/__init__.py
+++ b/opensea/__init__.py
@@ -1,5 +1,5 @@
 from .opensea import OpenSea
 
 
-def setup(bot):
-    bot.add_cog(OpenSea(bot))
+async def setup(bot):
+    await bot.add_cog(OpenSea(bot))

--- a/opensea/opensea.py
+++ b/opensea/opensea.py
@@ -1,5 +1,5 @@
 from redbot.core.utils.chat_formatting import pagify
-from redbot.core import Config, commands, checks
+from redbot.core import Config, commands
 from redbot.core.bot import Red
 from datetime import datetime
 from typing import Optional
@@ -207,7 +207,7 @@ class OpenSea(commands.Cog):
 
         return remove_channels
 
-    @checks.mod_or_permissions(manage_messages=True)
+    @commands.mod_or_permissions(manage_messages=True)
     @commands.group(aliases=["os"])
     async def opensea(self, ctx):
         """Receive events from OpenSea regarding assets."""
@@ -355,7 +355,7 @@ class OpenSea(commands.Cog):
         for page in pagify(message, delims=["\n", ","]):
             await ctx.send(page)
 
-    @checks.is_owner()
+    @commands.is_owner()
     @opensea.command(hidden=True)
     async def forceupdate(self, ctx):
         """Force an update of all subscribed channels."""

--- a/reacticket/__init__.py
+++ b/reacticket/__init__.py
@@ -1,5 +1,5 @@
 from .reacticket import ReacTicket
 
 
-def setup(bot):
-    bot.add_cog(ReacTicket(bot))
+async def setup(bot):
+    await bot.add_cog(ReacTicket(bot))

--- a/scanner/__init__.py
+++ b/scanner/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(Scanner(bot))
+async def setup(bot):
+    await bot.add_cog(Scanner(bot))

--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -30,7 +30,7 @@ import traceback
 
 import aiohttp
 import discord
-from redbot.core import Config, checks, commands
+from redbot.core import Config, commands
 from redbot.core.utils.chat_formatting import humanize_list, inline
 
 URL = "https://api.sightengine.com/1.0/check.json"
@@ -350,7 +350,7 @@ class Scanner(commands.Cog):
                 "".join(traceback.format_exception(type(error), error, error.__traceback__))
             )
 
-    @checks.admin_or_permissions(manage_messages=True)
+    @commands.admin_or_permissions(manage_messages=True)
     @commands.group()
     async def scanner(self, ctx):
         """Group command for changing scanner's settings."""
@@ -426,7 +426,7 @@ class Scanner(commands.Cog):
                 await self.conf.guild(ctx.guild).roles.set(new)
             await ctx.send(embed=e)
 
-    @checks.is_owner()
+    @commands.is_owner()
     @scanner.command()
     async def creds(self, ctx, user, secret):
         """Set the API user and API secret to use with requests from sightengine.com."""
@@ -771,7 +771,7 @@ class Scanner(commands.Cog):
             data["checks"] = []
         await ctx.send("Message moderation check update successful")
 
-    @checks.is_owner()
+    @commands.is_owner()
     @mm.command(name="enable")
     async def messagemoderation_enable(self, ctx, yes_or_no: bool):
         """Set whether or not to check for Message Mderation."""

--- a/simon/simon.py
+++ b/simon/simon.py
@@ -26,7 +26,7 @@ import asyncio
 import random
 
 import discord
-from redbot.core import checks, commands
+from redbot.core import commands
 
 
 class Simon(commands.Cog):
@@ -44,7 +44,7 @@ class Simon(commands.Cog):
         """This cog does not store user data"""
         return
 
-    @checks.bot_has_permissions(add_reactions=True)
+    @commands.bot_has_permissions(add_reactions=True)
     @commands.command()
     async def simon(self, ctx):
         """Start a game of Simon."""

--- a/sw/__init__.py
+++ b/sw/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(SW(bot))
+async def setup(bot):
+    await bot.add_cog(SW(bot))

--- a/sw/sw.py
+++ b/sw/sw.py
@@ -27,7 +27,7 @@ from typing import Union
 
 import aiohttp
 import discord
-from redbot.core import checks, commands
+from redbot.core import commands
 from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 
 from .image import (
@@ -62,7 +62,7 @@ class SW(commands.Cog):
         """This cog does not store user data"""
         return
 
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     @commands.group(name="swapi", aliases=["starwars"])
     async def starwars(self, ctx):
         """Group command for interacting with the Star Wars API"""

--- a/targeter/__init__.py
+++ b/targeter/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(Targeter(bot))
+async def setup(bot):
+    await bot.add_cog(Targeter(bot))

--- a/targeter/targeter.py
+++ b/targeter/targeter.py
@@ -877,7 +877,7 @@ class Targeter(commands.Cog):
         desc = (
             "`--format` - How to display results.  At the moment, must be `page` for posting on a website, or `menu` for showing the results in Discord.\n"
             "\n"
-            "If at any time you need to include quotes at the beginning or ending of something (such as a nickname or a role), include a slash (\) right before it."
+            "If at any time you need to include quotes at the beginning or ending of something (such as a nickname or a role), include a slash (\\) right before it."
         )
         special.description = desc
         special.set_footer(text="Target Arguments - Special Notes; Page 6/6")

--- a/targeter/targeter.py
+++ b/targeter/targeter.py
@@ -31,7 +31,7 @@ import csv
 import aiohttp
 import discord
 from dateutil.parser import parse
-from redbot.core import checks, commands
+from redbot.core import commands
 from redbot.core.commands import BadArgument, Converter, RoleConverter
 from redbot.core.utils.chat_formatting import humanize_list, pagify
 from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
@@ -731,7 +731,7 @@ class Targeter(commands.Cog):
         matched = await self.bot.loop.run_in_executor(None, compact)
         return matched
 
-    @checks.bot_has_permissions(embed_links=True)
+    @commands.bot_has_permissions(embed_links=True)
     @commands.guild_only()
     @commands.group(invoke_without_command=True)
     async def target(self, ctx, *, args: Args):
@@ -802,11 +802,11 @@ class Targeter(commands.Cog):
         desc = (
             "`--nick <nickone> <nicktwo>` - Users must have one of the passed nicks in their nickname.  If they don't have a nickname, they will instantly be excluded.\n"
             "`--user <userone> <usertwo>` - Users must have one of the passed usernames in their real username.  This will not look at nicknames.\n"
-            "`--name <nameone> <nametwo>` - Users must have one of the passed names in their username, and if they don't have one, their username.\n"
+            "`--name <nameone> <nametwo>` - Users must have one of the passed names in their nickname, and if they don't have one, their username.\n"
             "\n"
             "`--not-nick <nickone> <nicktwo>` - Users must not have one of the passed nicks in their nickname.  If they don't have a nickname, they will instantly be excluded.\n"
             "`--not-user <userone> <usertwo>` - Users must not have one of the passed usernames in their real username.  This will not look at nicknames.\n"
-            "`--not-name <nameone> <nametwo>` - Users must not have one of the passed names in their username, and if they don't have one, their username.\n"
+            "`--not-name <nameone> <nametwo>` - Users must not have one of the passed names in their nickname, and if they don't have one, their username.\n"
             "\n"
             "`--a-nick` - Users must have a nickname in the server.\n"
             "`--no-nick` - Users cannot have a nickname in the server."

--- a/twenty/__init__.py
+++ b/twenty/__init__.py
@@ -5,5 +5,5 @@ __red_end_user_data_statement__ = (
 )
 
 
-def setup(bot):
-    bot.add_cog(Twenty(bot))
+async def setup(bot):
+    await bot.add_cog(Twenty(bot))

--- a/twenty/twenty.py
+++ b/twenty/twenty.py
@@ -27,7 +27,7 @@ import random
 from copy import deepcopy as dc
 
 import discord
-from redbot.core import checks, commands
+from redbot.core import commands
 
 
 class Twenty(commands.Cog):
@@ -42,7 +42,7 @@ class Twenty(commands.Cog):
         """This cog does not store user data"""
         return
 
-    @checks.bot_has_permissions(add_reactions=True)
+    @commands.bot_has_permissions(add_reactions=True)
     @commands.command()
     async def twenty(self, ctx):
         """Starts a 2048 game inside of Discord."""

--- a/updatechecker/__init__.py
+++ b/updatechecker/__init__.py
@@ -7,4 +7,4 @@ __red_end_user_data_statement__ = (
 
 async def setup(bot):
     cog = UpdateChecker(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/updatechecker/updatechecker.py
+++ b/updatechecker/updatechecker.py
@@ -37,7 +37,7 @@ from typing import Optional
 import aiohttp
 import discord
 from redbot.cogs.downloader.repo_manager import Repo
-from redbot.core import Config, checks, commands
+from redbot.core import Config, commands
 from redbot.core.utils.chat_formatting import humanize_list, inline
 
 import feedparser
@@ -264,13 +264,13 @@ class UpdateChecker(commands.Cog):
             return None
         return ret
 
-    @checks.is_owner()
+    @commands.is_owner()
     @commands.group(name="cogupdater", aliases=["cu"])
     async def update(self, ctx):
         """Group command for controlling the update checker cog."""
         pass
 
-    @checks.is_owner()
+    @commands.is_owner()
     @update.command()
     async def auto(self, ctx):
         """Changes automatic cog updates to the opposite setting."""
@@ -284,7 +284,7 @@ class UpdateChecker(commands.Cog):
                 "This command is disabled for the time being.  Cog updates will not run automatically, however notifications will still send."
             )
 
-    @checks.is_owner()
+    @commands.is_owner()
     @update.command()
     async def channel(self, ctx, channel: discord.TextChannel = None):
         """Sets a channel for update messages to go to.
@@ -297,7 +297,7 @@ class UpdateChecker(commands.Cog):
             await self.conf.gochannel.set(0)
             await ctx.send("Update messages will now be DMed to you.")
 
-    @checks.is_owner()
+    @commands.is_owner()
     @update.command()
     async def settings(self, ctx):
         """See settings for the Update Checker cog.
@@ -336,7 +336,7 @@ class UpdateChecker(commands.Cog):
             )
             await ctx.send(message)
 
-    @checks.is_owner()
+    @commands.is_owner()
     @update.command()
     async def embed(self, ctx):
         """Toggles whether to use embeds or colorful codeblock messages when sending an update."""
@@ -345,7 +345,7 @@ class UpdateChecker(commands.Cog):
         word = "disabled" if c else "enabled"
         await ctx.send(f"Embeds are now {word}")
 
-    @checks.is_owner()
+    @commands.is_owner()
     @update.group(name="list")
     async def whiteblacklist(self, ctx):
         """Whitelist/blacklist certain repositories from which to receive updates."""
@@ -423,7 +423,7 @@ class UpdateChecker(commands.Cog):
         await self.conf.blacklist.set([])
         await ctx.send("Blacklist update successful")
 
-    @checks.is_owner()
+    @commands.is_owner()
     @update.group(name="task")
     async def _group_update_task(self, ctx):
         """View the status of the task (the one checking for updates)."""


### PR DESCRIPTION
Updates all non-hidden cogs (with the exception of Dashboard, which is being handled by #79) to support Red 3.5.
Additionally, references to `redbot.core.checks` are replaced with `redbot.core.commands`, and a few minor bugs are fixed.
The cogs which do not require API keys have been tested, though I did a sanity read of the code for all of the cogs.