### PR TITLE
[ReacTicket] Fix bug with [p]reacticket expecting ctx param

### DIFF
--- a/reacticket/extensions/base.py
+++ b/reacticket/extensions/base.py
@@ -7,7 +7,7 @@ import asyncio
 
 
 from reacticket.extensions.abc import MixinMeta
-from reacticket.extensions.mixin import reacticket
+from reacticket.extensions.mixin import RTMixin
 
 if discord.__version__ == "2.0.0a" or TYPE_CHECKING:
     from reacticket.extensions.views.queue import Queue
@@ -159,7 +159,7 @@ class ReacTicketBaseMixin(MixinMeta):
                             "permission in the category."
                         )
 
-    @reacticket.command()
+    @RTMixin.reacticket.command()
     async def close(self, ctx, *, reason=None):
         """Closes the created ticket.
 
@@ -244,7 +244,7 @@ class ReacTicketBaseMixin(MixinMeta):
             added_users=added_users,
         )
 
-    @reacticket.command(name="add")
+    @RTMixin.reacticket.command(name="add")
     async def ticket_add(self, ctx, user: discord.Member):
         """Add a user to the current ticket."""
         guild_settings = await self.config.guild(ctx.guild).all()
@@ -329,7 +329,7 @@ class ReacTicketBaseMixin(MixinMeta):
 
         await ctx.send(f"{user.mention} has been added to the ticket.")
 
-    @reacticket.command(name="remove")
+    @RTMixin.reacticket.command(name="remove")
     async def ticket_remove(self, ctx, user: discord.Member):
         """Remove a user from the current ticket."""
         guild_settings = await self.config.guild(ctx.guild).all()
@@ -411,7 +411,7 @@ class ReacTicketBaseMixin(MixinMeta):
 
         await ctx.send(f"{user.mention} has been removed from the ticket.")
 
-    @reacticket.command(name="name")
+    @RTMixin.reacticket.command(name="name")
     async def ticket_name(self, ctx, *, name: str):
         """Rename the ticket in scope."""
         guild_settings = await self.config.guild(ctx.guild).all()
@@ -544,7 +544,7 @@ class ReacTicketBaseMixin(MixinMeta):
         return commands.check(predicate)
 
     @is_support_or_superior()
-    @reacticket.command(aliases=["unlock"])
+    @RTMixin.reacticket.command(aliases=["unlock"])
     async def lock(self, ctx, channel: Optional[discord.TextChannel] = None):
         """Lock the specified ticket channel.  If no channel is provided, defaults to current.
 
@@ -591,7 +591,7 @@ class ReacTicketBaseMixin(MixinMeta):
                     break
 
     @is_support_or_superior()
-    @reacticket.command(aliases=["moderator", "mod"])
+    @RTMixin.reacticket.command(aliases=["moderator", "mod"])
     async def assign(
         self, ctx, moderator: discord.Member, ticket: Optional[discord.TextChannel] = None
     ):
@@ -673,7 +673,7 @@ class ReacTicketBaseMixin(MixinMeta):
     @on_discord_alpha()
     @is_support_or_superior()
     @commands.bot_has_permissions(embed_links=True)
-    @reacticket.command(aliases=["tickets"])
+    @RTMixin.reacticket.command(aliases=["tickets"])
     async def queue(self, ctx):
         """List, modify and close tickets sorted based upon when they were opened"""
         unsorted_tickets = await self.config.guild(ctx.guild).created()

--- a/reacticket/extensions/basesettings.py
+++ b/reacticket/extensions/basesettings.py
@@ -6,11 +6,11 @@ import asyncio
 import copy
 
 from reacticket.extensions.abc import MixinMeta
-from reacticket.extensions.mixin import settings
+from reacticket.extensions.mixin import RTMixin
 
 
 class ReacTicketBaseSettingsMixin(MixinMeta):
-    @settings.group(name="precreationsettings", aliases=["precs"])
+    @RTMixin.settings.group(name="precreationsettings", aliases=["precs"])
     async def pre_creation_settings(self, ctx):
         """Control the actions that are checked/occur before ticket is created"""
         pass
@@ -131,7 +131,7 @@ class ReacTicketBaseSettingsMixin(MixinMeta):
                 "Max number of tickets per user and DM setting have been successfully updated."
             )
 
-    @settings.group(name="postcreationsettings", aliases=["postcs"])
+    @RTMixin.settings.group(name="postcreationsettings", aliases=["postcs"])
     async def post_creation_settings(self, ctx):
         """Control the actions that occur post the ticket being created"""
         pass
@@ -311,7 +311,7 @@ class ReacTicketBaseSettingsMixin(MixinMeta):
         await self.config.guild(ctx.guild).presetname.set(settings)
         await ctx.send("Successfully changed selected ticket name preset.")
 
-    @settings.command()
+    @RTMixin.settings.command()
     async def enable(self, ctx, yes_or_no: Optional[bool] = None):
         """Starts listening for the set Reaction on the set Message to process tickets"""
         # We'll run through a test of all the settings to ensure everything is set properly
@@ -450,7 +450,7 @@ class ReacTicketBaseSettingsMixin(MixinMeta):
 
         await ctx.send("All checks passed.  Ticket system is now active.")
 
-    @settings.command()
+    @RTMixin.settings.command()
     async def disable(self, ctx):
         """Disable ticketing system"""
         await self.config.guild(ctx.guild).enabled.set(False)

--- a/reacticket/extensions/closesettings.py
+++ b/reacticket/extensions/closesettings.py
@@ -5,7 +5,7 @@ import discord
 import contextlib
 
 from reacticket.extensions.abc import MixinMeta
-from reacticket.extensions.mixin import settings
+from reacticket.extensions.mixin import RTMixin
 
 
 class ReacTicketCloseSettingsMixin(MixinMeta):

--- a/reacticket/extensions/closesettings.py
+++ b/reacticket/extensions/closesettings.py
@@ -9,7 +9,7 @@ from reacticket.extensions.mixin import settings
 
 
 class ReacTicketCloseSettingsMixin(MixinMeta):
-    @settings.group()
+    @RTMixin.settings.group()
     async def closesettings(self, ctx):
         """Control what actions occur when a ticket is closed"""
         pass

--- a/reacticket/extensions/mixin.py
+++ b/reacticket/extensions/mixin.py
@@ -1,49 +1,43 @@
 from redbot.core import commands, checks
 
 
-@checks.bot_has_permissions(add_reactions=True)
-@commands.guild_only()
-@commands.group(name="reacticket")
-async def reacticket(self, ctx: commands.Context):
-    """Create a reaction ticket system in your server"""
-    pass
-
-
-@checks.admin()
-@reacticket.group(invoke_without_command=True, aliases=["set"])
-async def settings(self, ctx):
-    """Manage settings for ReacTicket"""
-    await ctx.send_help()
-    guild_settings = await self.config.guild(ctx.guild).all()
-    channel_id, message_id = list(map(int, guild_settings["msg"].split("-")))
-
-    ticket_channel = getattr(self.bot.get_channel(channel_id), "name", "Not set")
-    ticket_category = getattr(self.bot.get_channel(guild_settings["category"]), "name", "Not set")
-    archive_category = getattr(
-        self.bot.get_channel(guild_settings["archive"]["category"]), "name", "Not set"
-    )
-    report_channel = getattr(self.bot.get_channel(guild_settings["report"]), "name", "Not set")
-
-    await ctx.send(
-        "```ini\n"
-        f"[Ticket Channel]:    {ticket_channel}\n"
-        f"[Ticket MessageID]:  {message_id}\n"
-        f"[Ticket Reaction]:   {guild_settings['reaction']}\n"
-        f"[User-closable]:     {guild_settings['usercanclose']}\n"
-        f"[User-modifiable]:   {guild_settings['usercanmodify']}\n"
-        f"[User-nameable]:     {guild_settings['usercanclose']}\n"
-        f"[Ticket Category]:   {ticket_category}\n"
-        f"[Report Channel]:    {report_channel}\n"
-        f"[Ticket Close DM]:   {guild_settings['dm']}\n"
-        f"[Archive Category]:  {archive_category}\n"
-        f"[Archive Enabled]:   {guild_settings['archive']['enabled']}\n"
-        f"[System Enabled]:    {guild_settings['enabled']}\n"
-        "```"
-    )
-
-
 class RTMixin:
     """ This is mostly here to easily mess with things... """
+    @checks.bot_has_permissions(add_reactions=True)
+    @commands.guild_only()
+    @commands.group(name="reacticket")
+    async def reacticket(self, ctx: commands.Context):
+        """Create a reaction ticket system in your server"""
+        pass
 
-    c = reacticket
-    s = settings
+    @checks.admin()
+    @reacticket.group(invoke_without_command=True, aliases=["set"])
+    async def settings(self, ctx):
+        """Manage settings for ReacTicket"""
+        await ctx.send_help()
+        guild_settings = await self.config.guild(ctx.guild).all()
+        channel_id, message_id = list(map(int, guild_settings["msg"].split("-")))
+
+        ticket_channel = getattr(self.bot.get_channel(channel_id), "name", "Not set")
+        ticket_category = getattr(self.bot.get_channel(guild_settings["category"]), "name", "Not set")
+        archive_category = getattr(
+            self.bot.get_channel(guild_settings["archive"]["category"]), "name", "Not set"
+        )
+        report_channel = getattr(self.bot.get_channel(guild_settings["report"]), "name", "Not set")
+
+        await ctx.send(
+            "```ini\n"
+            f"[Ticket Channel]:    {ticket_channel}\n"
+            f"[Ticket MessageID]:  {message_id}\n"
+            f"[Ticket Reaction]:   {guild_settings['reaction']}\n"
+            f"[User-closable]:     {guild_settings['usercanclose']}\n"
+            f"[User-modifiable]:   {guild_settings['usercanmodify']}\n"
+            f"[User-nameable]:     {guild_settings['usercanclose']}\n"
+            f"[Ticket Category]:   {ticket_category}\n"
+            f"[Report Channel]:    {report_channel}\n"
+            f"[Ticket Close DM]:   {guild_settings['dm']}\n"
+            f"[Archive Category]:  {archive_category}\n"
+            f"[Archive Enabled]:   {guild_settings['archive']['enabled']}\n"
+            f"[System Enabled]:    {guild_settings['enabled']}\n"
+            "```"
+        )

--- a/reacticket/extensions/usersettings.py
+++ b/reacticket/extensions/usersettings.py
@@ -5,7 +5,7 @@ from reacticket.extensions.mixin import RTMixin
 
 
 class ReacTicketUserSettingsMixin(MixinMeta):
-    @RTMixin.group()
+    @RTMixin.settings.group()
     async def userpermissions(self, ctx):
         """Control the permissions that users have with their own tickets"""
         pass

--- a/reacticket/extensions/usersettings.py
+++ b/reacticket/extensions/usersettings.py
@@ -1,11 +1,11 @@
 from typing import Optional
 
 from reacticket.extensions.abc import MixinMeta
-from reacticket.extensions.mixin import settings
+from reacticket.extensions.mixin import RTMixin
 
 
 class ReacTicketUserSettingsMixin(MixinMeta):
-    @settings.group()
+    @RTMixin.group()
     async def userpermissions(self, ctx):
         """Control the permissions that users have with their own tickets"""
         pass


### PR DESCRIPTION
Because `[p]reacticket` (and its subcommand `settings`) were defined outside of a class, then manually put in one, it was not getting passed an instance of `self`. This made `self` become a `Context` object, and `ctx` a required param. I moved the command definitions within the class it would eventually be defined in, and made the references to those commands in other files use the new path to those commands instead.